### PR TITLE
Fix subscriber's context cancellation

### DIFF
--- a/caster.go
+++ b/caster.go
@@ -55,7 +55,6 @@ func New(ctx context.Context) *Caster {
 	topLoop:
 		for {
 			select {
-
 			case <-ctx.Done():
 				break topLoop
 			case o := <-c.op:
@@ -76,6 +75,7 @@ func New(ctx context.Context) *Caster {
 				case opSub:
 					sIn := o.operand.(subInfo)
 					unSubCh := make(chan struct{})
+					subs[sIn.ch] = unSubCh
 					go func() {
 						select {
 						case <-sIn.ctx.Done():
@@ -83,7 +83,6 @@ func New(ctx context.Context) *Caster {
 						case <-unSubCh:
 						}
 					}()
-					subs[sIn.ch] = unSubCh
 				case opUnsub:
 					sCh := o.operand.(chan interface{})
 					if unSubCh, ok := subs[sCh]; ok {

--- a/caster.go
+++ b/caster.go
@@ -50,42 +50,24 @@ func New(ctx context.Context) *Caster {
 	}
 
 	go func() {
-		subs := map[chan interface{}]context.Context{}
-
-		checkCtx := func(sCh chan interface{}, sCtx context.Context) bool {
-			select {
-			case <-sCtx.Done():
-				delete(subs, sCh)
-				close(sCh)
-				return false
-			default:
-				return true
-			}
-		}
+		subs := make(map[chan interface{}]chan struct{})
 
 	topLoop:
 		for {
 			select {
+
 			case <-ctx.Done():
 				break topLoop
 			case o := <-c.op:
 				switch o.operator {
 				case opPub:
-					for sCh, sCtx := range subs {
-						if !checkCtx(sCh, sCtx) {
-							continue
-						}
-
+					for sCh := range subs {
 						select {
 						case sCh <- o.operand:
 						}
 					}
 				case opTryPub:
-					for sCh, sCtx := range subs {
-						if !checkCtx(sCh, sCtx) {
-							continue
-						}
-
+					for sCh := range subs {
 						select {
 						case sCh <- o.operand:
 						default:
@@ -93,18 +75,30 @@ func New(ctx context.Context) *Caster {
 					}
 				case opSub:
 					sIn := o.operand.(subInfo)
-					subs[sIn.ch] = sIn.ctx
+					unSubCh := make(chan struct{})
+					go func() {
+						select {
+						case <-sIn.ctx.Done():
+							c.Unsub(sIn.ch)
+						case <-unSubCh:
+						}
+					}()
+					subs[sIn.ch] = unSubCh
 				case opUnsub:
 					sCh := o.operand.(chan interface{})
-					delete(subs, sCh)
-					close(sCh)
+					if unSubCh, ok := subs[sCh]; ok {
+						close(unSubCh)
+						delete(subs, sCh)
+						close(sCh)
+					}
 				case opClose:
 					break topLoop
 				}
 			}
 		}
 
-		for sCh := range subs {
+		for sCh, unSubCh := range subs {
+			close(unSubCh)
 			close(sCh)
 		}
 
@@ -148,8 +142,10 @@ func (c *Caster) Sub(ctx context.Context, capacity uint) (sCh chan interface{}, 
 	select {
 	case <-ctx.Done():
 		close(sCh)
+		ok = false
 	case <-c.done:
 		close(sCh)
+		ok = false
 	case c.op <- operation{
 		operator: opSub,
 		operand: subInfo{
@@ -158,7 +154,6 @@ func (c *Caster) Sub(ctx context.Context, capacity uint) (sCh chan interface{}, 
 		},
 	}:
 	}
-
 	ok = true
 	return
 }


### PR DESCRIPTION
Currently the cancellation of subscribers context doesn't always work: checkCtx runs only on "Pub" and a not-busy caster won't close subscriber's channel immediately. 
My solution starts an extra go routine for every new subscriber, which will unsubscribe as soon as it's context is canceled. For the case that never happens (e.g. context.Background) an extra channel is created and stored in "subs" map which is closed on un-subscription and prevents the context go routine from leaking